### PR TITLE
fixed reading disk error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,4 @@ x86_64-elf-gcc -Ttext 0x8000 -ffreestanding -mno-red-zone -m64 -c "./Kernel/kern
 x86_64-elf-ld -T"link.ld"
 cd ./bin
 cat boot.bin kernel.bin >> boot.bin
-qemu-system-x86_64 boot.bin
+qemu-system-x86_64 -fda boot.bin

--- a/run1.sh
+++ b/run1.sh
@@ -8,4 +8,4 @@ nasm -f bin ./Sector2+/extendedProg.asm -o ./bin/extendedProg.bin
 # x86_64-elf-ld -T"link.ld"
 cd ./bin
 cat boot.bin extendedProg.bin >> boot.bin
-qemu-system-x86_64 boot.bin
+qemu-system-x86_64 -fda boot.bin

--- a/run3.sh
+++ b/run3.sh
@@ -10,4 +10,4 @@ x86_64-elf-ld -o ./bin/kernel.tmp -Ttext 0x7e00 ./bin/extendedProg.o ./bin/kerne
 x86_64-elf-objcopy -O binary ./bin/kernel.tmp ./bin/kernel.bin
 cd ./bin
 cat boot.bin kernel.bin >> boot.bin
-qemu-system-x86_64 boot.bin
+qemu-system-x86_64 -fda boot.bin


### PR DESCRIPTION
The run files did not have the -fda option. without this option it will not  have a disk to read